### PR TITLE
[adreno] Fix avg_pool2d

### DIFF
--- a/tvm/python/tvm/topi/adreno/pooling.py
+++ b/tvm/python/tvm/topi/adreno/pooling.py
@@ -62,6 +62,7 @@ def schedule_pool(outs, layout):
             s[OL].vectorize(s[OL].op.axis[-1])
         else:
             s[Pool].compute_at(s[Out], tx)
+            s[Pool].vectorize(s[Pool].op.axis[-1])
 
     scheduled_ops = []
 


### PR DESCRIPTION
* `avg_pool2d` is not properly vectorized, resulting in 4x duplicate work.
* Because `avg_pool2d` has two stages, i.e. `pool_sum` and `elemwise`, the schedule function takes `else` branch, where vectorization on the innermost axis is missing.