### PR TITLE
[adreno] Texture support in more ops

### DIFF
--- a/tvm/CMakeLists.txt
+++ b/tvm/CMakeLists.txt
@@ -206,7 +206,9 @@ endif()
 if(BUILD_FOR_ANDROID)
   # EmuTLS on Android is in libgcc. Without it linked in, libtvm_runtime.so
   # won't load on Android due to missing __emutls_XXX symbols.
-  list(APPEND TVM_RUNTIME_LINKER_LIBS "gcc")
+  if(${ANDROID_NDK_MAJOR} VERSION_LESS "23")
+    list(APPEND TVM_RUNTIME_LINKER_LIBS "gcc")
+  endif()
 endif()
 
 # add source group

--- a/tvm/apps/cpp_rpc/CMakeLists.txt
+++ b/tvm/apps/cpp_rpc/CMakeLists.txt
@@ -32,7 +32,9 @@ endif()
 
 if(USE_OPENCL)
   if (ANDROID_ABI)
-    set_property(TARGET tvm_rpc PROPERTY LINK_FLAGS -fuse-ld=gold)
+    if(${ANDROID_NDK_MAJOR} VERSION_LESS "23")
+      set_property(TARGET tvm_rpc PROPERTY LINK_FLAGS -fuse-ld=gold)
+    endif()
   endif()
 endif()
 

--- a/tvm/apps/cpp_rpc/rpc_tracker_client.h
+++ b/tvm/apps/cpp_rpc/rpc_tracker_client.h
@@ -111,7 +111,7 @@ class TrackerClient {
 
       std::ostringstream ss;
       ss << "[" << static_cast<int>(TrackerCode::kPut) << ", \"" << key_ << "\", [" << port
-         << ", \"" << *matchkey << "\"], " << custom_addr_ << "]";
+         << ", \"" << *matchkey << "\"], \"" << custom_addr_ << "\"]";
 
       tracker_sock_.SendBytes(ss.str());
 
@@ -163,7 +163,7 @@ class TrackerClient {
 
             std::ostringstream ss;
             ss << "[" << static_cast<int>(TrackerCode::kPut) << ", \"" << key_ << "\", [" << port
-               << ", \"" << *matchkey << "\"], " << custom_addr_ << "]";
+               << ", \"" << *matchkey << "\"], \"" << custom_addr_ << "\"]";
             tracker_sock_.SendBytes(ss.str());
 
             std::string remote_status = tracker_sock_.RecvBytes();

--- a/tvm/python/tvm/driver/build_module.py
+++ b/tvm/python/tvm/driver/build_module.py
@@ -176,6 +176,7 @@ def lower(sch, args, name="main", binds=None, simple_mode=False):
     pass_list += [
         tvm.tir.transform.InjectPrefetch(),
         tvm.tir.transform.TextureFlatten(),
+        tvm.tir.transform.RewriteTextureConditionals(),
         tvm.tir.transform.StorageFlatten(64, instrument_bound_checkers),
         tvm.tir.transform.BF16Legalize(),
         tvm.tir.transform.NarrowDataType(32),

--- a/tvm/python/tvm/relay/op/strategy/adreno.py
+++ b/tvm/python/tvm/relay/op/strategy/adreno.py
@@ -154,10 +154,10 @@ def schedule_concatenate_adreno(attrs, outs, target):
         else:
             return topi.cuda.schedule_injective(outs)
 
-#@schedule_injective.register("adreno")
-#def schedule_injective_adreno(attrs, outs, target):
-#    with target:
-#        if attrs.src_layout == "NCHW4c" or attrs.dst_layout == "NCHW4c":
-#            return topi.adreno.schedule_injective(outs)
-#        else:
-#            return topi.cuda.schedule_injective(outs)
+@schedule_injective.register("adreno")
+def schedule_injective_adreno(attrs, outs, target):
+    with target:
+        if is_nchw4c(outs):
+            return topi.adreno.schedule_injective(outs)
+        else:
+            return topi.cuda.schedule_injective(outs)

--- a/tvm/python/tvm/relay/op/strategy/adreno.py
+++ b/tvm/python/tvm/relay/op/strategy/adreno.py
@@ -140,3 +140,16 @@ def schedule_pool_adreno(attrs, outs, target):
             return topi.adreno.schedule_pool(outs, attrs.layout)
         else:
             return topi.cuda.schedule_pool(outs, attrs.layout)
+
+@schedule_concatenate.register("adreno")
+def schedule_concatenate_adreno(attrs, outs, target):
+    with target:
+        return topi.adreno.schedule_concatenate(outs)
+
+#@schedule_injective.register("adreno")
+#def schedule_injective_adreno(attrs, outs, target):
+#    with target:
+#        if attrs.src_layout == "NCHW4c" or attrs.dst_layout == "NCHW4c":
+#            return topi.adreno.schedule_injective(outs)
+#        else:
+#            return topi.cuda.schedule_injective(outs)

--- a/tvm/python/tvm/tir/transform/transform.py
+++ b/tvm/python/tvm/tir/transform/transform.py
@@ -107,6 +107,23 @@ def TextureFlatten():
     """
     return _ffi_api.TextureFlatten()
 
+def RewriteTextureConditionals():
+    """Rewrites if_then_else(texture2d_load()) to texture2d_load(if_then_else).
+
+    In particular, it rewrites the above pattern so that the condition is placed
+    on the coordinates. Originally, if_then_else chooses between texture2d_load
+    and 0. After rewrite, if_then_else chooses between a valid coordinate and
+    -1, allowing utilizing hardware OOB handling.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.RewriteTextureConditionals()
 
 def InjectCopyIntrin(pragma_key, fintrin):
     """Inject virtual thread loops.

--- a/tvm/python/tvm/topi/adreno/__init__.py
+++ b/tvm/python/tvm/topi/adreno/__init__.py
@@ -22,3 +22,4 @@ from .conv2d_tpack import *
 from .conv2d_nhwc import *
 from .depthwise_conv2d_nhwc import *
 from .pooling import *
+from .injective import *

--- a/tvm/python/tvm/topi/adreno/conv2d.py
+++ b/tvm/python/tvm/topi/adreno/conv2d.py
@@ -272,19 +272,19 @@ def schedule_conv2d_NCHWc_KCRSk(cfg, s, output, args={}):
     elif args["shared"]:
         AA = s.cache_read(pad_data, "shared", [OL])
         WW = s.cache_read(kernel, "shared", [OL])
-    else:
-        AT = s.cache_read(pad_data, "texture", [OL])
-        def copy_to_texture(stage):
-            axes = s[stage].op.axis
-            fused = s[stage].fuse(*axes[:-1])
-            shape = get_const_tuple(stage.shape)
-            ftc = numpy.prod(shape[:-1])
-            div = getDiv(ftc, 64)
-            block, thread = s[stage].split(fused, factor=div)
-            s[stage].vectorize(axes[-1])
-            s[stage].bind(block, te.thread_axis("blockIdx.x"))
-            s[stage].bind(thread, te.thread_axis("threadIdx.x"))
-        copy_to_texture(AT)
+    #else:
+    #    AT = s.cache_read(pad_data, "texture", [OL])
+    #    def copy_to_texture(stage):
+    #        axes = s[stage].op.axis
+    #        fused = s[stage].fuse(*axes[:-1])
+    #        shape = get_const_tuple(stage.shape)
+    #        ftc = numpy.prod(shape[:-1])
+    #        div = getDiv(ftc, 64)
+    #        block, thread = s[stage].split(fused, factor=div)
+    #        s[stage].vectorize(axes[-1])
+    #        s[stage].bind(block, te.thread_axis("blockIdx.x"))
+    #        s[stage].bind(thread, te.thread_axis("threadIdx.x"))
+    #    copy_to_texture(AT)
 
     # tile and bind spatial axes
     n, fc, y, x, fb = s[output].op.axis

--- a/tvm/python/tvm/topi/adreno/injective.py
+++ b/tvm/python/tvm/topi/adreno/injective.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-variable,
+"""Schedule for composition of injective operator"""
+import tvm
+from tvm import te
+from .. import utils
+
+
+def schedule_concatenate_from_existing(sch, out):
+    """Schedule for injective op from existing schedule.
+
+    Parameters
+    ----------
+    sch: Schedule
+         The schedule to update.
+    out: Tensor
+         The tensor representing the injective op.
+
+    Returns
+    -------
+    sch: Schedule
+         The updated schedule.
+    """
+    fused = sch[out].fuse(*sch[out].op.axis[:-1])
+    num_thread = tvm.target.Target.current(allow_none=False).max_num_threads
+    
+    bx, tx = sch[out].split(fused, factor=num_thread)
+    sch[out].bind(tx, te.thread_axis("threadIdx.x"))
+    sch[out].bind(bx, te.thread_axis("blockIdx.x"))
+    sch[out].vectorize(sch[out].op.axis[-1])
+
+    return sch
+
+
+def schedule_concatenate(outs):
+    """Schedule for injective op.
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of injective in the format
+          of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
+    s = te.create_schedule([x.op for x in outs])
+
+    tvm.te.schedule.AutoInlineInjective(s)
+    for out in outs:
+        if not utils.is_empty_shape(out.shape):
+            schedule_concatenate_from_existing(s, out)
+    return s
+
+
+#schedule_elemwise = schedule_injective
+#schedule_broadcast = schedule_injective

--- a/tvm/src/relay/transforms/annotate_texture_storage.cc
+++ b/tvm/src/relay/transforms/annotate_texture_storage.cc
@@ -276,6 +276,8 @@ class StorageInfo : private ExprVisitor{
       if (attrs->layout == "NCHW4c") {
         supports_texture_storage = true;
       }
+    } else if (auto attrs = call->attrs.as<ConcatenateAttrs>()) {
+      supports_texture_storage = true;
     }
 
     return supports_texture_storage;

--- a/tvm/src/relay/transforms/annotate_texture_storage.cc
+++ b/tvm/src/relay/transforms/annotate_texture_storage.cc
@@ -308,6 +308,30 @@ class StorageInfo : private ExprVisitor{
       if (isNCHW4c(call)) {
         supports_texture_storage = true;
       }
+    } else if (auto attrs = call->attrs.as<PadAttrs>()) {
+      if (isNCHW4c(call)) {
+      supports_texture_storage = true;
+      }
+    } else if (const OpNode *op = call->op.as<OpNode>()) {
+      String op_name = op->name;
+      //LOG(INFO) << "op node: " << op_name;
+      if (op_name == "add") {
+        if (isNCHW4c(call)) {
+        supports_texture_storage = true;
+        }
+      } else if (op_name == "multiply") {
+        if (isNCHW4c(call)) {
+        supports_texture_storage = true;
+        }
+      } else if (op_name == "maximum") {
+        if (isNCHW4c(call)) {
+        supports_texture_storage = true;
+        }
+      } else if (op_name == "nn.relu") {
+        if (isNCHW4c(call)) {
+        supports_texture_storage = true;
+        }
+      }
     }
 
     return supports_texture_storage;

--- a/tvm/src/target/source/codegen_opencl.cc
+++ b/tvm/src/target/source/codegen_opencl.cc
@@ -427,7 +427,12 @@ void CodeGenOpenCL::VisitExpr_(const CallNode* op, std::ostream& os) {
       PrintExpr(op->args[0], os);
       os << ")";
     } else {
-      CodeGenC::VisitExpr_(op, os);
+      std::string true_expr = SSAGetID(PrintExpr(op->args[1]), op->args[1]->dtype);
+      std::string false_expr = SSAGetID(PrintExpr(op->args[2]), op->args[2]->dtype);
+      os << "(";
+      PrintExpr(op->args[0], os);
+      os << " ? " << true_expr << " : " << false_expr;
+      os << ")";
     }
   } else {
     CodeGenC::VisitExpr_(op, os);

--- a/tvm/src/target/source/codegen_opencl.h
+++ b/tvm/src/target/source/codegen_opencl.h
@@ -77,6 +77,10 @@ class CodeGenOpenCL final : public CodeGenC {
   // Whether to enable atomics extension.
   bool enable_atomics_{false};
   bool need_texture_ssa_{true};
+  // Marks whether we are lowering tir.texture2d_load().
+  // If we are, we will lower tir.if_then_else() to select(), otherwise
+  // we will keep the default lowering (i.e. to ternary op ? :).
+  bool lowering_texture2d_load_{false};
   std::unordered_map<const Object*, int32_t> allocation_size_;
 };
 

--- a/tvm/src/tir/transforms/texture_rewrite.cc
+++ b/tvm/src/tir/transforms/texture_rewrite.cc
@@ -1,0 +1,87 @@
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/buffer.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/stmt.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+namespace tvm {
+namespace tir {
+/**
+ * This pass attempts to rewrite texture2d_load() calls to take advantage of
+ * hardware OOB handling.  After ScheduleOp(), the generated IR contains the 
+ * following pattern for OOB handling:
+ *   tir.if_then_else(cond, tir.texture2d_load(), 0)
+ * where cond decides if the coordinates in tir.texture2d_load() is OOB.
+ * This pass attempts to rewrite the above pattern to the following,
+ *   tir.texture2d_load(handle, tir.if_then_else(cond, row_coord, -1), ...)
+ * i.e. if cond predicates that the access is OOB, we directly pass -1 as
+ * x coord in tir.texture2d_load(), which automatically returns 0.
+ *
+ * Correspondingly in the OpenCL codegen, tir.if_then_else() will be lowered
+ * to select() when lowering calls to tir.texture2d_load(). The original
+ * ternary ? : would result in branching instructions whereas select() usually
+ * does not.
+ *
+ * An alternative to this is to change the OpenCL codegen to lower
+ * tir.if_then_else to select(); however, this would result in more verbose code
+ * due to the ambiguity when using select().
+ */
+class RewriteTextureConditionalsPass : public StmtExprMutator {
+public:
+  PrimExpr VisitExpr_(const CallNode* op) override {
+    PrimExpr expr = StmtExprMutator::VisitExpr_(op);
+    op = expr.as<CallNode>();
+
+    if (op->op.same_as(builtin::if_then_else())) {
+      ICHECK_EQ(op->args.size(), 3) << "if_then_else should take 3 args";
+      PrimExpr cond = op->args[0];
+      const CallNode* call_node = op->args[1].as<CallNode>();
+      const FloatImmNode* false_val = op->args[2].as<FloatImmNode>();
+
+      if (call_node && false_val && false_val->value == 0) {
+        if (call_node->op.same_as(builtin::texture2d_load())) {
+          PrimExpr handle = call_node->args[0];
+          PrimExpr row_offset = call_node->args[1];
+          PrimExpr col_offset = call_node->args[2];
+          PrimExpr idx = call_node->args[3];
+
+          PrimExpr row_offset_cond = Call(
+              row_offset.dtype(),
+              builtin::if_then_else(),
+              {cond, row_offset, -1});
+          PrimExpr new_texture2d_load = Call(
+              call_node->dtype,
+              builtin::texture2d_load(),
+              {handle, row_offset_cond, col_offset, idx});
+          return new_texture2d_load;
+        }
+      }
+    }
+
+    return expr;
+  }
+};
+
+PrimFunc RewriteTextureConditionals(PrimFunc func) {
+  auto fptr = func.CopyOnWrite();
+  fptr->body = RewriteTextureConditionalsPass()(fptr->body);
+  return func;
+}
+
+namespace transform {
+
+Pass RewriteTextureConditionals() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    return RewriteTextureConditionals(std::move(f));
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tir.RemoveTextureConditionals", {});
+}
+
+TVM_REGISTER_GLOBAL("tir.transform.RewriteTextureConditionals").set_body_typed(RewriteTextureConditionals);
+
+} // namespace transform
+} // namespace tir
+} // namespace tvm


### PR DESCRIPTION
This PR contains changes for performance improvement. It also contains minor fixes for NDK 23 and `cpp_rpc`; these have already been fixed in the mainline TVM. In particular, this PR contains,
1. A simple schedule for injective ops on Adreno GPU.
2. Texture support for some additional ops - `concat`, `add`, `relu`, `maximum`, `multiply`, `pad`
3. Use `select` in OpenCL codegen for texture access.
4. A more general CL codegen improvement that should make the resulting code easier for the OpenCL compiler to optimize.
5. Disable `cache_read(texture)`.