### PR TITLE
Specify fcompile in export_library

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -1398,7 +1398,7 @@ class Executor(object):
                 ctx = self.remote.cl(0)
             else:
                 ctx = self.remote.cpu(0)
-            lib.export_library(dso_binary_path, ndk.create_shared)
+            lib.export_library(dso_binary_path, fcompile=ndk.create_shared)
             remote_path = "/data/local/tmp/" + dso_binary
             self.remote.upload(dso_binary_path)
             print("Uploading binary...")
@@ -1489,7 +1489,7 @@ class Executor(object):
                 ctx = self.remote.cl(0)
             else:
                 ctx = self.remote.cpu(0)
-            vmc.mod.export_library(dso_binary_path, ndk.create_shared)
+            vmc.mod.export_library(dso_binary_path, fcompile=ndk.create_shared)
             self.remote.upload(dso_binary_path)
             print("Uploading binary...")
             rlib = self.remote.load_module(dso_binary)

--- a/evaluate_dyn_models.py
+++ b/evaluate_dyn_models.py
@@ -325,7 +325,7 @@ def build_model_ge(mod, params):
             mod, target_host=args.target_host, target=args.target, params=params
         )
     if "android" in args.rpc_key:
-        lib.export_library(lib_path, ndk.create_shared)
+        lib.export_library(lib_path, fcompile=ndk.create_shared)
     else:
         lib.export_library(lib_path)
     return lib, lib_path, graph, params
@@ -340,7 +340,7 @@ def build_model_vm(mod, params):
     with tvm.transform.PassContext(opt_level=3):
         vmc = relay.vm.compile(vm_mod, target=args.target, target_host=args.target_host, params=params)
         if "android" in args.rpc_key:
-            vmc.mod.export_library(lib_path, ndk.create_shared)
+            vmc.mod.export_library(lib_path, fcompile=ndk.create_shared)
         else:
             vmc.mod.export_library(lib_path)
 


### PR DESCRIPTION
After commit f9e6018cfe in TVM mainline, all parameters in `export_library` after `file_name` started to be keyword-only parameters.